### PR TITLE
Fixed cars rotating on some turns

### DIFF
--- a/js/roads.js
+++ b/js/roads.js
@@ -385,6 +385,13 @@ var Car = function(carTile, carSpeed) {
 
             }
 
+            // fix for rotating cars
+            if (this.targetAngle - this.angle > 180) {
+                this.angle += 360;
+            } else if (this.angle - this.targetAngle > 180) {
+                this.angle -= 360;
+            }
+
             if (this.targetAngle > this.angle) {
                 this.angle += 15;
             } else if (this.targetAngle < this.angle) {
@@ -510,9 +517,9 @@ function render() {
 window.requestAnimFrame = (function() {
 	return  window.requestAnimationFrame       ||
 	window.webkitRequestAnimationFrame ||
-	window.mozRequestAnimationFrame    || 
-	window.oRequestAnimationFrame      || 
-	window.msRequestAnimationFrame     || 
+	window.mozRequestAnimationFrame    ||
+	window.oRequestAnimationFrame      ||
+	window.msRequestAnimationFrame     ||
 	function( callback ) {
 	    window.setTimeout(callback, 1000 / 60);
 	};


### PR DESCRIPTION
On some turns the cars just rotated to other side. This was caused by the case when car rotated from e.g. 270 degrees to 360 degrees (which is 0 degrees), so it rotated 270 -> 0 instead of 270 -> 360.

This fixes it in this way: when the direction car needs to turn is more than 180 degrees, it adds / substracts 360 from current angle, so in example above, the car would turn from -30 to 0.

And also removed some white characters (PhpStorm did)